### PR TITLE
Added ssh-agent function to .bashrc_custom

### DIFF
--- a/.bashrc_custom
+++ b/.bashrc_custom
@@ -1,1 +1,26 @@
+####### Modified to generate ssh-agent at login for github connect#######
+#########################################################################
+####TAKEN FROM http://www.cygwin.com/ml/cygwin/2001-06/msg00537.html ####
 
+SSH_ENV="$HOME/.ssh/environment"
+
+function start_agent {
+     echo "Initialising new SSH agent..."
+     /usr/bin/ssh-agent | sed 's/^echo/#echo/' > "${SSH_ENV}"
+     echo succeeded
+     chmod 600 "${SSH_ENV}"
+     . "${SSH_ENV}" > /dev/null
+     /usr/bin/ssh-add;
+}
+
+# Source SSH settings, if applicable
+
+if [ -f "${SSH_ENV}" ]; then
+     . "${SSH_ENV}" > /dev/null
+     #ps ${SSH_AGENT_PID} doesn't work under cywgin
+     ps -ef | grep ${SSH_AGENT_PID} | grep ssh-agent$ > /dev/null || {
+         start_agent;
+     }
+else
+     start_agent;
+fi


### PR DESCRIPTION
Added an ssh-agent function provided publicly here http://www.cygwin.com/ml/cygwin/2001-06/msg00537.html

Step 2 of the github ssh key instructions recommend setting up a passphrase for your keys and using something like ssh-agent:
https://help.github.com/articles/generating-ssh-keys
This allows ubuntu to prompt you for a password for a session at login, but from there on will continue to allow password-less entry
